### PR TITLE
chore: release v0.1.0-alpha.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0-alpha.5](https://github.com/sidrubs/potree-embed/compare/v0.1.0-alpha.4...v0.1.0-alpha.5) - 2025-07-25
+
+### Fixed
+
+- *(potree-deps)* Downgrade to Gulp 4
+
 ## [0.1.0](https://github.com/sidrubs/potree-embed/releases/tag/v0.1.0) - 2025-06-05
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,7 +187,7 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "potree-embed"
-version = "0.1.0-alpha.4"
+version = "0.1.0-alpha.5"
 dependencies = [
  "rust-embed",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "potree-embed"
-version = "0.1.0-alpha.4"
+version = "0.1.0-alpha.5"
 edition = "2024"
 license = "MIT"
 description = "Built `potree` static files in a `rust-embed` struct so that they can be embedded into a Rust application."


### PR DESCRIPTION



## 🤖 New release

* `potree-embed`: 0.1.0-alpha.4 -> 0.1.0-alpha.5 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.0-alpha.5](https://github.com/sidrubs/potree-embed/compare/v0.1.0-alpha.4...v0.1.0-alpha.5) - 2025-07-25

### Fixed

- *(potree-deps)* Downgrade to Gulp 4
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).